### PR TITLE
adding unit test case TestDecryptConfigMapWrongkey for crypto

### DIFF
--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -68,14 +68,17 @@ func TestEncryptConfigMapFiles(t *testing.T) {
 		t.Errorf("Failed to encrypt configMap %v", err)
 	}
 
-	decryptedConfigMap := decryptConfigMap(encConfigMap, keyPath, noncePath)
+	decryptedConfigMap, err := decryptConfigMap(encConfigMap, keyPath, noncePath)
+	if err != nil {
+		t.Errorf("Failed to decrypt configMap %v", err)
+	}
 
 	if testString != decryptedConfigMap {
 		t.Errorf("Failed to match decryped string, expected %s but got %s", testString, decryptedConfigMap)
 	}
 }
 
-func decryptConfigMap(configMap string, keyPath string, noncePath string) string {
+func decryptConfigMap(configMap string, keyPath string, noncePath string) (string, error) {
 
 	sDec, _ := b64.StdEncoding.DecodeString(configMap)
 
@@ -84,27 +87,97 @@ func decryptConfigMap(configMap string, keyPath string, noncePath string) string
 	//The keys are base64 encoded. Decode it before passing to encryption function
 	keyDecoded, err := b64.StdEncoding.DecodeString(string(key))
 	if err != nil {
-		panic(err.Error())
+		return "", err
 	}
 	nonceDecoded, err := b64.StdEncoding.DecodeString(string(nonce))
 	if err != nil {
-		panic(err.Error())
+		return "", err
 	}
 
 	block, err := aes.NewCipher(keyDecoded)
 	if err != nil {
-		panic(err.Error())
+		return "", err
 	}
 
 	aesgcm, err := cipher.NewGCM(block)
 	if err != nil {
-		panic(err.Error())
+		return "", err
 	}
 
 	plaintextBytes, err := aesgcm.Open(nil, nonceDecoded, sDec, nil)
 	if err != nil {
-		panic(err.Error())
+		return "", err
 	}
 
-	return string(plaintextBytes)
+	return string(plaintextBytes), nil
+}
+
+func TestDecryptConfigMapWrongkey(t *testing.T) {
+	/*Test Objective : A new unit test case, TestDecryptConfigMapWrongkey is being
+	added for crypto. In this test, behavior of passing wrong key value
+	is being tested. In present behavior, decrypt functions retuns the global var
+	when value passed is non NULL.*/
+
+	testString := "Sample String to Test Symmetric Encryption"
+
+	dir1, err := ioutil.TempDir("", "TestEncryption-2")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(dir1)
+
+	keyPath := dir1 + "symmKeyFile"
+	wrongkeyPath := dir1 + "wrongsymmKeyFile"
+
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		t.Error(err)
+	}
+	wrongkey := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, wrongkey); err != nil {
+		t.Error(err)
+	}
+
+	//Encode the Key
+	keyEnc := b64.StdEncoding.EncodeToString(key)
+	//encode wrong key
+	wrongkeyEnc := b64.StdEncoding.EncodeToString(wrongkey)
+
+	err = ioutil.WriteFile(keyPath, []byte(keyEnc), 0644)
+	if err != nil {
+		t.Error(err)
+	}
+	err = ioutil.WriteFile(wrongkeyPath, []byte(wrongkeyEnc), 0644)
+	if err != nil {
+		t.Error(err)
+	}
+
+	noncePath := dir1 + "nonceFile"
+	nonce := make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		t.Error(err)
+	}
+
+	//Encode the nonce
+	nonceEnc := b64.StdEncoding.EncodeToString(nonce)
+
+	err = ioutil.WriteFile(noncePath, []byte(nonceEnc), 0644)
+	if err != nil {
+		t.Error(err)
+	}
+
+	encConfigMap, err := EncryptConfigMap([]byte(testString), keyPath, noncePath)
+	if err != nil {
+		t.Errorf("Failed to encrypt configMap %v", err)
+	}
+
+	wrongdecryptedConfigMap, err := decryptConfigMap(encConfigMap, wrongkeyPath, noncePath)
+	if err != nil {
+		t.Errorf("Failed to decrypt configMap %v", err)
+	}
+
+	if testString != wrongdecryptedConfigMap {
+		t.Logf("Failed to match decryped string, expected %s but got %s", testString, wrongdecryptedConfigMap)
+		t.FailNow()
+	}
 }


### PR DESCRIPTION
Test Objective : A new unit test case, TestDecryptConfigMapWrongkey  is being added for crypto. In Symmetric encryption, only one key (a secret key) is used to both encrypt and decrypt. In this test, behavior of passing wrong key value is being tested.